### PR TITLE
Persist data to JSON by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ env.json
 cache/*
 .ipynb_checkpoints
 __pycache__
+output/*
+.idea

--- a/cryptoart_footprint.py
+++ b/cryptoart_footprint.py
@@ -25,8 +25,8 @@ summary = defaultdict(lambda: defaultdict(int))
 if not args.summary:
     print(f'Name\tKind\tAddress\tGas\tTransactions\tkgCO2')
 
-output = {}
-output['data'] = []
+output_json = {}
+output_json['data'] = []
 for name_kind, address in contracts.items():
     if name_kind == 'Nifty Gateway/multiple':
         if args.ng:
@@ -51,7 +51,7 @@ for name_kind, address in contracts.items():
             "transactions": len(transactions),
             "kgco2": kgco2
         }
-        output['data'].append(row)
+        output_json['data'].append(row)
 
         if args.commas:
             print(f'{name}\t{kind}\t{address}\t{gas:,}\t{len(transactions):,}\t{kgco2:,}')
@@ -66,4 +66,4 @@ if args.summary:
         kgco2 = summary[name]['kgco2']
         print(f'{name}\t{gas:,}\t{transactions:,}\t{kgco2:,}')
 
-write_results(output)
+write_results(output_json)

--- a/cryptoart_footprint.py
+++ b/cryptoart_footprint.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from etherscan import Etherscan, sum_gas
 from ethereum_footprint import EthereumFootprint
 from nifty_gateway import list_nifty_gateway
-from utils import load_contacts, load_etherscan_api_key, write_results
+from utils import load_contracts, load_etherscan_api_key, write_results
 
 parser = argparse.ArgumentParser(description='Estimate emissions footprint for CryptoArt platforms.')
 parser.add_argument('--ng', action='store_true', help='Estimate footprint for Nifty Gateway.')
@@ -15,7 +15,7 @@ parser.add_argument('--verbose', action='store_true', help='Verbose mode.')
 args = parser.parse_args()
 
 api_key = load_etherscan_api_key()
-contracts = load_contacts()
+contracts = load_contracts()
 
 etherscan = Etherscan(api_key)
 ethereum_footprint = EthereumFootprint()

--- a/cryptoart_footprint.py
+++ b/cryptoart_footprint.py
@@ -47,12 +47,12 @@ for name_kind, address in contracts.items():
 
     if not args.summary:
         row = {
-            "name": name,
-            "kind": kind,
-            "address": address,
-            "gas": gas,
-            "transactions": len(transactions),
-            "kgco2": kgco2
+            'name': name,
+            'kind': kind,
+            'address': address,
+            'gas': gas,
+            'transactions': len(transactions),
+            'kgco2': kgco2
         }
         output_json['data'].append(row)
 
@@ -62,10 +62,10 @@ if args.summary:
         transactions = summary[name]['transactions']
         kgco2 = summary[name]['kgco2']
         row = {
-            "name": name,
-            "gas": gas,
-            "transactions": transactions,
-            "kgco2": kgco2
+            'name': name,
+            'gas': gas,
+            'transactions': transactions,
+            'kgco2': kgco2
         }
         output_json['data'].append(row)
 

--- a/cryptoart_footprint.py
+++ b/cryptoart_footprint.py
@@ -26,21 +26,25 @@ output_json = {}
 output_json['data'] = []
 
 def load_transactions():
-    if name_kind == 'Nifty Gateway/multiple' and args.ng:
+    if name_kind == 'Nifty Gateway/multiple':
         transactions = etherscan.load_transactions_multiple(list_nifty_gateway(args.verbose), verbose=args.verbose)
     else:
         transactions = etherscan.load_transactions(address, verbose=args.verbose)
     return transactions
 
 for name_kind, address in contracts.items():
-    transactions = load_transactions()
+    # Skip Nifty Gateway if user doesn't ask for it
+    if name_kind == 'Nifty Gateway/multiple' and not args.ng:
+        continue
 
+    transactions = load_transactions()
     gas = sum_gas(transactions)
     kgco2 = int(ethereum_footprint.sum_kgco2(transactions))
     name, kind = name_kind.split('/')
     summary[name]['gas'] += gas
     summary[name]['transactions'] += len(transactions)
     summary[name]['kgco2'] += kgco2
+
     if not args.summary:
         row = {
             "name": name,
@@ -60,7 +64,7 @@ if args.summary:
         row = {
             "name": name,
             "gas": gas,
-            "transactions": len(transactions),
+            "transactions": transactions,
             "kgco2": kgco2
         }
         output_json['data'].append(row)

--- a/cryptoart_footprint.py
+++ b/cryptoart_footprint.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from etherscan import Etherscan, sum_gas
 from ethereum_footprint import EthereumFootprint
 from nifty_gateway import list_nifty_gateway
+from utils import load_contacts, load_etherscan_api_key, write_results
 
 parser = argparse.ArgumentParser(description='Estimate emissions footprint for CryptoArt platforms.')
 parser.add_argument('--ng', action='store_true', help='Estimate footprint for Nifty Gateway.')
@@ -13,18 +14,19 @@ parser.add_argument('--commas', action='store_true', help='Print with comma sepa
 parser.add_argument('--verbose', action='store_true', help='Verbose mode.')
 args = parser.parse_args()
 
-with open('env.json') as f:
-    apikey = json.load(f)['etherscan-api-key']
-    
-with open('data/contracts.json') as f:
-    contracts = json.load(f)
+api_key = load_etherscan_api_key()
+contracts = load_contacts()
 
-etherscan = Etherscan(apikey)
+etherscan = Etherscan(api_key)
 ethereum_footprint = EthereumFootprint()
 
 summary = defaultdict(lambda: defaultdict(int))
+
 if not args.summary:
     print(f'Name\tKind\tAddress\tGas\tTransactions\tkgCO2')
+
+output = {}
+output['data'] = []
 for name_kind, address in contracts.items():
     if name_kind == 'Nifty Gateway/multiple':
         if args.ng:
@@ -37,10 +39,20 @@ for name_kind, address in contracts.items():
     gas = sum_gas(transactions)
     kgco2 = int(ethereum_footprint.sum_kgco2(transactions))
     name, kind = name_kind.split('/')
-    summary[name]['gas'] += gas 
+    summary[name]['gas'] += gas
     summary[name]['transactions'] += len(transactions)
     summary[name]['kgco2'] += kgco2
     if not args.summary:
+        row = {
+            "name": name,
+            "kind": kind,
+            "address": address,
+            "gas": gas,
+            "transactions": len(transactions),
+            "kgco2": kgco2
+        }
+        output['data'].append(row)
+
         if args.commas:
             print(f'{name}\t{kind}\t{address}\t{gas:,}\t{len(transactions):,}\t{kgco2:,}')
         else:
@@ -53,3 +65,5 @@ if args.summary:
         transactions = summary[name]['transactions']
         kgco2 = summary[name]['kgco2']
         print(f'{name}\t{gas:,}\t{transactions:,}\t{kgco2:,}')
+
+write_results(output)

--- a/output/.gitignore
+++ b/output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ First, sign up for an API key at [Etherscan](https://etherscan.io/myapikey). Cre
 
 Install requests `pip install requests` if it is not already available.
 
-Then run the script: `python cryptoart_footprint.py > footprint.tsv`
+Then run the script: `python cryptoart_footprint.py`
 
 This may take longer the first time, while your local cache is updated.
 
@@ -38,8 +38,7 @@ Additional flags:
 
 * `--ng` to also estimate the footprint for Nifty Gateway. This takes much longer than other platforms, because Nifty Gateway uses a separate smart contract per exhibition/drop.
 * `--summary` to summarize the results in a format similar to the above table, combining multiple contracts into a single row of output.
-* `--commas` to print the output with thousands comma separators.
-* `--verbose` prints progress when scraping Nifty Gateway or pulling transactions from Etherscan. 
+* `--verbose` prints progress when scraping Nifty Gateway or pulling transactions from Etherscan.
 
 ## Methodology
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ First, sign up for an API key at [Etherscan](https://etherscan.io/myapikey). Cre
 
 Install requests `pip install requests` if it is not already available.
 
-Then run the script: `python cryptoart_footprint.py`
+Then run the script: `python cryptoart_footprint.py`. This will run the calculations and save current emissions data to `/output` directory in JSON.
 
 This may take longer the first time, while your local cache is updated.
 

--- a/utils.py
+++ b/utils.py
@@ -10,10 +10,10 @@ def load_contacts():
     with open('data/contracts.json') as file:
         return json.load(file)
 
-def write_results(output):
-    current_datetime = datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S')
+def write_results(output_json):
+    current_datetime = datetime.datetime.now().strftime('%Y-%m-%d at %H.%M.%S')
     result_filepath = f'./output/{current_datetime}.json'
     with open(result_filepath, 'w') as jsonFile:
-        json.dump(output, jsonFile)
+        json.dump(output_json, jsonFile)
         jsonFile.close()
-    print(f'Emissions results saved to {result_filepath}')
+    print(f'Emissions results saved to file: "{result_filepath}"')

--- a/utils.py
+++ b/utils.py
@@ -4,7 +4,7 @@ import datetime
 def load_etherscan_api_key():
     with open('env.json') as file:
         payload = json.load(file)
-        return payload['etherscan-api-key']
+    return payload['etherscan-api-key']
 
 def load_contracts():
     with open('data/contracts.json') as file:

--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,6 @@ def load_contracts():
 def write_results(output_json):
     current_datetime = datetime.datetime.now().strftime('%Y-%m-%d at %H.%M.%S')
     result_filepath = f'./output/{current_datetime}.json'
-    with open(result_filepath, 'w') as jsonFile:
-        json.dump(output_json, jsonFile)
-        jsonFile.close()
+    with open(result_filepath, 'w') as f:
+        json.dump(output_json, f)
     print(f'Emissions results saved to file: "{result_filepath}"')

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,7 @@ def load_etherscan_api_key():
         payload = json.load(file)
         return payload['etherscan-api-key']
 
-def load_contacts():
+def load_contracts():
     with open('data/contracts.json') as file:
         return json.load(file)
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,19 @@
+import json
+import datetime
+
+def load_etherscan_api_key():
+    with open('env.json') as file:
+        payload = json.load(file)
+        return payload['etherscan-api-key']
+
+def load_contacts():
+    with open('data/contracts.json') as file:
+        return json.load(file)
+
+def write_results(output):
+    current_datetime = datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S')
+    result_filepath = f'./output/{current_datetime}.json'
+    with open(result_filepath, 'w') as jsonFile:
+        json.dump(output, jsonFile)
+        jsonFile.close()
+    print(f'Emissions results saved to {result_filepath}')


### PR DESCRIPTION
Previously the script ran and had the user output to a `.tsv` file. This has been replaced with JSON to the `/output` direction.

The JSON format follows the following format:

```json
{
    "data": [
        {
            "name": "Async",
            "kind": "1",
            "address": "0x6c424c25e9f1fff9642cb5b7750b0db7312c29ad",
            "gas": 596562089,
            "transactions": 7410,
            "kgco2": 127053
        },
        {
            "name": "Async",
            "kind": "2",
            "address": "0xb6dae651468e9593e4581705a09c10a76ac1e0c8",
            "gas": 862954286,
            "transactions": 7304,
            "kgco2": 247305
        },
        ...
    ]
}
```