### PR TITLE
Remove 10k limit from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Estimate the total CO2 footprint for popular CryptoArt platforms. The goal is to accurately quantify the ecological damage of Ethereum 1.0 PoW-backed CryptoArt platforms.
 
-To estimate the footprint for a specific Ethereum wallet or contract (up to 10,000 transactions) try [carbon.fyi](https://carbon.fyi/). To estimate the footprint of a specific artwork try [cryptoart.wtf](http://cryptoart.wtf/).
+To estimate the footprint for a specific Ethereum wallet or contract try [carbon.fyi](https://carbon.fyi/). To estimate the footprint of a specific artwork try [cryptoart.wtf](http://cryptoart.wtf/).
 
 Status as of March 22, 2021:
 


### PR DESCRIPTION
Hello, we recently updated our [carbon.fyi](carbon.fyi) calculator and it is now able to compute emissions for adresses with more than 10,000 transactions. Would it be possible to reflect this change in your readme please?

Thanks!